### PR TITLE
Add per schema caching

### DIFF
--- a/src/__tests__/arktype.test.ts
+++ b/src/__tests__/arktype.test.ts
@@ -1,34 +1,31 @@
 import {describe, expect, jest, test} from '@jest/globals';
 import {type} from 'arktype';
 
-import {assert, clearCache, validate} from '..';
+import {assert, validate} from '..';
 import {ValidationIssue} from '../schema';
 
 describe('arktype', () => {
   const schema = type('string');
   const module = 'arktype';
 
+  test('peer dependency', async () => {
+    jest.mock(module, () => {
+      throw new Error('Cannot find module');
+    });
+    await expect(validate(schema, '123')).rejects.toThrow();
+    await expect(assert(schema, '123')).rejects.toThrow();
+    jest.unmock(module);
+  });
+
   test('validate', async () => {
     expect(await validate(schema, '123')).toStrictEqual({data: '123'});
     expect(await validate(schema, 123)).toStrictEqual({
       issues: [new ValidationIssue('Must be a string (was number)')],
     });
-    clearCache();
-    jest.mock(module, () => {
-      throw new Error('Cannot find module');
-    });
-    await expect(validate(schema, '123')).rejects.toThrow();
-    jest.unmock(module);
   });
 
   test('assert', async () => {
     expect(await assert(schema, '123')).toStrictEqual('123');
     await expect(assert(schema, 123)).rejects.toThrow();
-    clearCache();
-    jest.mock(module, () => {
-      throw new Error('Cannot find module');
-    });
-    await expect(assert(schema, '123')).rejects.toThrow();
-    jest.unmock(module);
   });
 });

--- a/src/__tests__/arktype.test.ts
+++ b/src/__tests__/arktype.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, jest, test} from '@jest/globals';
 import {type} from 'arktype';
 
-import {assert, validate} from '..';
+import {assert, clearCache, validate} from '..';
 import {ValidationIssue} from '../schema';
 
 describe('arktype', () => {
@@ -13,6 +13,7 @@ describe('arktype', () => {
     expect(await validate(schema, 123)).toStrictEqual({
       issues: [new ValidationIssue('Must be a string (was number)')],
     });
+    clearCache();
     jest.mock(module, () => {
       throw new Error('Cannot find module');
     });
@@ -23,6 +24,7 @@ describe('arktype', () => {
   test('assert', async () => {
     expect(await assert(schema, '123')).toStrictEqual('123');
     await expect(assert(schema, 123)).rejects.toThrow();
+    clearCache();
     jest.mock(module, () => {
       throw new Error('Cannot find module');
     });

--- a/src/__tests__/joi.test.ts
+++ b/src/__tests__/joi.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, jest, test} from '@jest/globals';
 import Joi from 'joi';
 
-import {assert, validate} from '..';
+import {assert, clearCache, validate} from '..';
 import {ValidationIssue} from '../schema';
 
 describe('joi', () => {
@@ -13,6 +13,7 @@ describe('joi', () => {
     expect(await validate(schema, 123)).toStrictEqual({
       issues: [new ValidationIssue('"value" must be a string')],
     });
+    clearCache();
     jest.mock(module, () => {
       throw new Error('Cannot find module');
     });
@@ -23,6 +24,7 @@ describe('joi', () => {
   test('assert', async () => {
     expect(await assert(schema, '123')).toStrictEqual('123');
     await expect(assert(schema, 123)).rejects.toThrow();
+    clearCache();
     jest.mock(module, () => {
       throw new Error('Cannot find module');
     });

--- a/src/__tests__/joi.test.ts
+++ b/src/__tests__/joi.test.ts
@@ -1,34 +1,31 @@
 import {describe, expect, jest, test} from '@jest/globals';
 import Joi from 'joi';
 
-import {assert, clearCache, validate} from '..';
+import {assert, validate} from '..';
 import {ValidationIssue} from '../schema';
 
 describe('joi', () => {
   const schema = Joi.string();
   const module = 'joi';
 
+  test('peer dependency', async () => {
+    jest.mock(module, () => {
+      throw new Error('Cannot find module');
+    });
+    await expect(validate(schema, '123')).rejects.toThrow();
+    await expect(assert(schema, '123')).rejects.toThrow();
+    jest.unmock(module);
+  });
+
   test('validate', async () => {
     expect(await validate(schema, '123')).toStrictEqual({data: '123'});
     expect(await validate(schema, 123)).toStrictEqual({
       issues: [new ValidationIssue('"value" must be a string')],
     });
-    clearCache();
-    jest.mock(module, () => {
-      throw new Error('Cannot find module');
-    });
-    await expect(validate(schema, '123')).rejects.toThrow();
-    jest.unmock(module);
   });
 
   test('assert', async () => {
     expect(await assert(schema, '123')).toStrictEqual('123');
     await expect(assert(schema, 123)).rejects.toThrow();
-    clearCache();
-    jest.mock(module, () => {
-      throw new Error('Cannot find module');
-    });
-    await expect(assert(schema, '123')).rejects.toThrow();
-    jest.unmock(module);
   });
 });

--- a/src/__tests__/runtypes.test.ts
+++ b/src/__tests__/runtypes.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, jest, test} from '@jest/globals';
 import {String} from 'runtypes';
 
-import {assert, validate} from '..';
+import {assert, clearCache, validate} from '..';
 import {ValidationIssue} from '../schema';
 
 describe('runtypes', () => {
@@ -13,6 +13,7 @@ describe('runtypes', () => {
     expect(await validate(schema, 123)).toStrictEqual({
       issues: [new ValidationIssue('Expected string, but was number')],
     });
+    clearCache();
     jest.mock(module, () => {
       throw new Error('Cannot find module');
     });
@@ -23,6 +24,7 @@ describe('runtypes', () => {
   test('assert', async () => {
     expect(await assert(schema, '123')).toStrictEqual('123');
     await expect(assert(schema, 123)).rejects.toThrow();
+    clearCache();
     jest.mock(module, () => {
       throw new Error('Cannot find module');
     });

--- a/src/__tests__/runtypes.test.ts
+++ b/src/__tests__/runtypes.test.ts
@@ -1,34 +1,31 @@
 import {describe, expect, jest, test} from '@jest/globals';
 import {String} from 'runtypes';
 
-import {assert, clearCache, validate} from '..';
+import {assert, validate} from '..';
 import {ValidationIssue} from '../schema';
 
 describe('runtypes', () => {
   const schema = String;
   const module = 'runtypes';
 
+  test('peer dependency', async () => {
+    jest.mock(module, () => {
+      throw new Error('Cannot find module');
+    });
+    await expect(validate(schema, '123')).rejects.toThrow();
+    await expect(assert(schema, '123')).rejects.toThrow();
+    jest.unmock(module);
+  });
+
   test('validate', async () => {
     expect(await validate(schema, '123')).toStrictEqual({data: '123'});
     expect(await validate(schema, 123)).toStrictEqual({
       issues: [new ValidationIssue('Expected string, but was number')],
     });
-    clearCache();
-    jest.mock(module, () => {
-      throw new Error('Cannot find module');
-    });
-    await expect(validate(schema, '123')).rejects.toThrow();
-    jest.unmock(module);
   });
 
   test('assert', async () => {
     expect(await assert(schema, '123')).toStrictEqual('123');
     await expect(assert(schema, 123)).rejects.toThrow();
-    clearCache();
-    jest.mock(module, () => {
-      throw new Error('Cannot find module');
-    });
-    await expect(assert(schema, '123')).rejects.toThrow();
-    jest.unmock(module);
   });
 });

--- a/src/__tests__/superstruct.test.ts
+++ b/src/__tests__/superstruct.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, jest, test} from '@jest/globals';
 import {string} from 'superstruct';
 
-import {assert, validate} from '..';
+import {assert, clearCache, validate} from '..';
 import {ValidationIssue} from '../schema';
 
 describe('superstruct', () => {
@@ -13,6 +13,7 @@ describe('superstruct', () => {
     expect(await validate(schema, 123)).toStrictEqual({
       issues: [new ValidationIssue('Expected a string, but received: 123')],
     });
+    clearCache();
     jest.mock(module, () => {
       throw new Error('Cannot find module');
     });
@@ -23,6 +24,7 @@ describe('superstruct', () => {
   test('assert', async () => {
     expect(await assert(schema, '123')).toStrictEqual('123');
     await expect(assert(schema, 123)).rejects.toThrow();
+    clearCache();
     jest.mock(module, () => {
       throw new Error('Cannot find module');
     });

--- a/src/__tests__/superstruct.test.ts
+++ b/src/__tests__/superstruct.test.ts
@@ -1,34 +1,31 @@
 import {describe, expect, jest, test} from '@jest/globals';
 import {string} from 'superstruct';
 
-import {assert, clearCache, validate} from '..';
+import {assert, validate} from '..';
 import {ValidationIssue} from '../schema';
 
 describe('superstruct', () => {
   const schema = string();
   const module = 'superstruct';
 
+  test('peer dependency', async () => {
+    jest.mock(module, () => {
+      throw new Error('Cannot find module');
+    });
+    await expect(validate(schema, '123')).rejects.toThrow();
+    await expect(assert(schema, '123')).rejects.toThrow();
+    jest.unmock(module);
+  });
+
   test('validate', async () => {
     expect(await validate(schema, '123')).toStrictEqual({data: '123'});
     expect(await validate(schema, 123)).toStrictEqual({
       issues: [new ValidationIssue('Expected a string, but received: 123')],
     });
-    clearCache();
-    jest.mock(module, () => {
-      throw new Error('Cannot find module');
-    });
-    await expect(validate(schema, '123')).rejects.toThrow();
-    jest.unmock(module);
   });
 
   test('assert', async () => {
     expect(await assert(schema, '123')).toStrictEqual('123');
     await expect(assert(schema, 123)).rejects.toThrow();
-    clearCache();
-    jest.mock(module, () => {
-      throw new Error('Cannot find module');
-    });
-    await expect(assert(schema, '123')).rejects.toThrow();
-    jest.unmock(module);
   });
 });

--- a/src/__tests__/typebox.test.ts
+++ b/src/__tests__/typebox.test.ts
@@ -1,34 +1,31 @@
 import {describe, expect, jest, test} from '@jest/globals';
 import {Type} from '@sinclair/typebox';
 
-import {assert, clearCache, validate} from '..';
+import {assert, validate} from '..';
 import {ValidationIssue} from '../schema';
 
 describe('typebox', () => {
   const schema = Type.String();
   const module = '@sinclair/typebox';
 
+  test('peer dependency', async () => {
+    jest.mock(module, () => {
+      throw new Error('Cannot find module');
+    });
+    await expect(validate(schema, '123')).rejects.toThrow();
+    await expect(assert(schema, '123')).rejects.toThrow();
+    jest.unmock(module);
+  });
+
   test('validate', async () => {
     expect(await validate(schema, '123')).toStrictEqual({data: '123'});
     expect(await validate(schema, 123)).toStrictEqual({
       issues: [new ValidationIssue('Expected string')],
     });
-    clearCache();
-    jest.mock(module, () => {
-      throw new Error('Cannot find module');
-    });
-    await expect(validate(schema, '123')).rejects.toThrow();
-    jest.unmock(module);
   });
 
   test('assert', async () => {
     expect(await assert(schema, '123')).toStrictEqual('123');
     await expect(assert(schema, 123)).rejects.toThrow();
-    clearCache();
-    jest.mock(module, () => {
-      throw new Error('Cannot find module');
-    });
-    await expect(assert(schema, '123')).rejects.toThrow();
-    jest.unmock(module);
   });
 });

--- a/src/__tests__/typebox.test.ts
+++ b/src/__tests__/typebox.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, jest, test} from '@jest/globals';
 import {Type} from '@sinclair/typebox';
 
-import {assert, validate} from '..';
+import {assert, clearCache, validate} from '..';
 import {ValidationIssue} from '../schema';
 
 describe('typebox', () => {
@@ -13,6 +13,7 @@ describe('typebox', () => {
     expect(await validate(schema, 123)).toStrictEqual({
       issues: [new ValidationIssue('Expected string')],
     });
+    clearCache();
     jest.mock(module, () => {
       throw new Error('Cannot find module');
     });
@@ -23,6 +24,7 @@ describe('typebox', () => {
   test('assert', async () => {
     expect(await assert(schema, '123')).toStrictEqual('123');
     await expect(assert(schema, 123)).rejects.toThrow();
+    clearCache();
     jest.mock(module, () => {
       throw new Error('Cannot find module');
     });

--- a/src/__tests__/yup.test.ts
+++ b/src/__tests__/yup.test.ts
@@ -1,12 +1,21 @@
 import {describe, expect, jest, test} from '@jest/globals';
 import {string} from 'yup';
 
-import {assert, clearCache, validate} from '..';
+import {assert, validate} from '..';
 import {ValidationIssue} from '../schema';
 
 describe('yup', () => {
   const schema = string();
   const module = 'yup';
+
+  test('peer dependency', async () => {
+    jest.mock(module, () => {
+      throw new Error('Cannot find module');
+    });
+    await expect(validate(schema, '123')).rejects.toThrow();
+    await expect(assert(schema, '123')).rejects.toThrow();
+    jest.unmock(module);
+  });
 
   test('validate', async () => {
     expect(await validate(schema, '123')).toStrictEqual({data: '123'});
@@ -17,22 +26,10 @@ describe('yup', () => {
         ),
       ],
     });
-    clearCache();
-    jest.mock(module, () => {
-      throw new Error('Cannot find module');
-    });
-    await expect(validate(schema, '123')).rejects.toThrow();
-    jest.unmock(module);
   });
 
   test('assert', async () => {
     expect(await assert(schema, '123')).toStrictEqual('123');
     await expect(assert(schema, 123)).rejects.toThrow();
-    clearCache();
-    jest.mock(module, () => {
-      throw new Error('Cannot find module');
-    });
-    await expect(assert(schema, '123')).rejects.toThrow();
-    jest.unmock(module);
   });
 });

--- a/src/__tests__/yup.test.ts
+++ b/src/__tests__/yup.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, jest, test} from '@jest/globals';
 import {string} from 'yup';
 
-import {assert, validate} from '..';
+import {assert, clearCache, validate} from '..';
 import {ValidationIssue} from '../schema';
 
 describe('yup', () => {
@@ -17,6 +17,7 @@ describe('yup', () => {
         ),
       ],
     });
+    clearCache();
     jest.mock(module, () => {
       throw new Error('Cannot find module');
     });
@@ -27,6 +28,7 @@ describe('yup', () => {
   test('assert', async () => {
     expect(await assert(schema, '123')).toStrictEqual('123');
     await expect(assert(schema, 123)).rejects.toThrow();
+    clearCache();
     jest.mock(module, () => {
       throw new Error('Cannot find module');
     });

--- a/src/__tests__/zod.test.ts
+++ b/src/__tests__/zod.test.ts
@@ -1,18 +1,14 @@
 import {describe, expect, jest, test} from '@jest/globals';
 import {z} from 'zod';
 
-import {assert, validate} from '..';
+import {assert, setCaching, validate} from '..';
 import {ValidationIssue} from '../schema';
 
 describe('zod', () => {
   const schema = z.string();
   const module = 'zod';
 
-  test('validate', async () => {
-    expect(await validate(schema, '123')).toStrictEqual({data: '123'});
-    expect(await validate(schema, 123)).toStrictEqual({
-      issues: [new ValidationIssue('Expected string, received number')],
-    });
+  test('do not validate with no zod dependency', async () => {
     jest.mock(module, () => {
       throw new Error('Cannot find module');
     });
@@ -20,13 +16,56 @@ describe('zod', () => {
     jest.unmock(module);
   });
 
-  test('assert', async () => {
-    expect(await assert(schema, '123')).toStrictEqual('123');
-    await expect(assert(schema, 123)).rejects.toThrow();
+  test('do not assert with no zod dependency', async () => {
     jest.mock(module, () => {
       throw new Error('Cannot find module');
     });
     await expect(assert(schema, '123')).rejects.toThrow();
     jest.unmock(module);
   });
+
+  test('validate', async () => {
+    expect(await validate(schema, '123')).toStrictEqual({data: '123'});
+    expect(await validate(schema, 123)).toStrictEqual({
+      issues: [new ValidationIssue('Expected string, received number')],
+    });
+  });
+
+  test('assert', async () => {
+    expect(await assert(schema, '123')).toStrictEqual('123');
+    await expect(assert(schema, 123)).rejects.toThrow();
+  });
+
+  test('performance', async () => {
+    const userSchema = z.object({
+      age: z.number().min(18),
+      email: z.string().email(),
+      id: z.number(),
+      name: z.string(),
+    });
+    const data = {
+      age: 18,
+      email: 'john.doe@test.com',
+      id: 1,
+      name: 'John Doe',
+    };
+    const iterations = 100000;
+    // with cache
+    setCaching(true);
+    const start = Date.now();
+    for (let i = 0; i < iterations; i++) {
+      await validate(userSchema, data);
+    }
+    const end = Date.now();
+    const cachedDuration = end - start;
+    // caching disabled
+    setCaching(false);
+    const start2 = Date.now();
+    for (let i = 0; i < iterations; i++) {
+      await validate(userSchema, data);
+    }
+    const end2 = Date.now();
+    const noCacheDuration = end2 - start2;
+    expect(cachedDuration).toBeLessThan(noCacheDuration);
+  }, 10000);
 });

--- a/src/__tests__/zod.test.ts
+++ b/src/__tests__/zod.test.ts
@@ -1,25 +1,18 @@
 import {describe, expect, jest, test} from '@jest/globals';
 import {z} from 'zod';
 
-import {assert, setCaching, validate} from '..';
+import {assert, validate} from '..';
 import {ValidationIssue} from '../schema';
 
 describe('zod', () => {
   const schema = z.string();
   const module = 'zod';
 
-  test('do not validate with no zod dependency', async () => {
+  test('peer dependency', async () => {
     jest.mock(module, () => {
       throw new Error('Cannot find module');
     });
     await expect(validate(schema, '123')).rejects.toThrow();
-    jest.unmock(module);
-  });
-
-  test('do not assert with no zod dependency', async () => {
-    jest.mock(module, () => {
-      throw new Error('Cannot find module');
-    });
     await expect(assert(schema, '123')).rejects.toThrow();
     jest.unmock(module);
   });
@@ -35,37 +28,4 @@ describe('zod', () => {
     expect(await assert(schema, '123')).toStrictEqual('123');
     await expect(assert(schema, 123)).rejects.toThrow();
   });
-
-  test('performance', async () => {
-    const userSchema = z.object({
-      age: z.number().min(18),
-      email: z.string().email(),
-      id: z.number(),
-      name: z.string(),
-    });
-    const data = {
-      age: 18,
-      email: 'john.doe@test.com',
-      id: 1,
-      name: 'John Doe',
-    };
-    const iterations = 100000;
-    // with cache
-    setCaching(true);
-    const start = Date.now();
-    for (let i = 0; i < iterations; i++) {
-      await validate(userSchema, data);
-    }
-    const end = Date.now();
-    const cachedDuration = end - start;
-    // caching disabled
-    setCaching(false);
-    const start2 = Date.now();
-    for (let i = 0; i < iterations; i++) {
-      await validate(userSchema, data);
-    }
-    const end2 = Date.now();
-    const noCacheDuration = end2 - start2;
-    expect(cachedDuration).toBeLessThan(noCacheDuration);
-  }, 10000);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import type {Schema} from './registry';
-import type {ValidationIssue} from './schema';
+import type {TypeSchema, ValidationIssue} from './schema';
 
 import {wrap} from './wrap';
 
@@ -8,10 +8,29 @@ export type {ValidationIssue} from './schema';
 
 export type Infer<TSchema> = TSchema extends Schema<infer T> ? T : never;
 
+const cache = new Map<Schema<any>, TypeSchema<any>>();
+let isCacheEnabled = true;
+
+export function clearCache() {
+  cache.clear();
+}
+
+export function setCaching(on: boolean) {
+  isCacheEnabled = on;
+}
+
 export async function validate<T>(
   schema: Schema<T>,
   data: unknown,
 ): Promise<{data: T} | {issues: Array<ValidationIssue>}> {
+  if (isCacheEnabled) {
+    let wrapped = cache.get(schema);
+    if (!wrapped) {
+      wrapped = await wrap(schema);
+      cache.set(schema, wrapped);
+    }
+    return wrapped.validate(data);
+  }
   return (await wrap(schema)).validate(data);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,37 +1,19 @@
 import type {Schema} from './registry';
-import type {TypeSchema, ValidationIssue} from './schema';
+import type {ValidationIssue} from './schema';
 
-import {wrap} from './wrap';
+import {wrap, wrapCached} from './wrap';
 
 export type {Schema} from './registry';
 export type {ValidationIssue} from './schema';
 
 export type Infer<TSchema> = TSchema extends Schema<infer T> ? T : never;
 
-const cache = new Map<Schema<any>, TypeSchema<any>>();
-let isCacheEnabled = true;
-
-export function clearCache() {
-  cache.clear();
-}
-
-export function setCaching(on: boolean) {
-  isCacheEnabled = on;
-}
-
 export async function validate<T>(
   schema: Schema<T>,
   data: unknown,
 ): Promise<{data: T} | {issues: Array<ValidationIssue>}> {
-  if (isCacheEnabled) {
-    let wrapped = cache.get(schema);
-    if (!wrapped) {
-      wrapped = await wrap(schema);
-      cache.set(schema, wrapped);
-    }
-    return wrapped.validate(data);
-  }
-  return (await wrap(schema)).validate(data);
+  const wrappedSchema = wrapCached(schema) ?? (await wrap(schema));
+  return wrappedSchema.validate(data);
 }
 
 export async function assert<T>(schema: Schema<T>, data: unknown): Promise<T> {

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -3,12 +3,20 @@ import type {TypeSchema} from './schema';
 
 import {adapters} from './registry';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const cachedWrappedSchemas = new Map<Schema<any>, TypeSchema<any>>();
+
 let lastUsedAdapter: Adapter | null = null;
+
+export function wrapCached<T>(schema: Schema<T>): TypeSchema<T> | null {
+  return cachedWrappedSchemas.get(schema) as TypeSchema<T> | null;
+}
 
 export async function wrap<T>(schema: Schema<T>): Promise<TypeSchema<T>> {
   if (lastUsedAdapter != null) {
     const wrappedSchema = await lastUsedAdapter(schema);
     if (wrappedSchema != null) {
+      cachedWrappedSchemas.set(schema, wrappedSchema);
       return wrappedSchema;
     }
   }
@@ -37,5 +45,6 @@ export async function wrap<T>(schema: Schema<T>): Promise<TypeSchema<T>> {
   }
 
   lastUsedAdapter = results[0].adapter;
+  cachedWrappedSchemas.set(schema, results[0].wrappedSchema);
   return results[0].wrappedSchema;
 }


### PR DESCRIPTION
Hello,

I tested performance impact of running coerce each time we validate a schema,
it turns out it's pretty bad. We have around X4 to X6 performance impact.
I got zod to validate 100_000 times the same schemas in 2s while typeschema did it in 12s.
So, here is a PR for pragmatic use of the library.

Indeed, users usually create only a few schemas and validate against them a lot of time.
So this PR is to get rid of doing a coerce and doing async await a bunch of time in the process by putting the resolved validator in a cache handled by a Map.

So it turn out this appoach is more performant. now perf only degrade to 1.5X to 2X slower than using zod directly.
So instead of validating 100_000 times in 2s it validates in 3s. it's much better.
