### PR TITLE
Replace sed command with function to make the build more portable.

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,23 @@
+import {readFileSync, writeFileSync} from 'fs';
 import {defineConfig} from 'tsup';
+
+function replaceStringInFile(
+  filePath: string,
+  searchString: string,
+  replaceString: string,
+): () => Promise<void> {
+  return async () => {
+    try {
+      const updatedContent = readFileSync(filePath, 'utf-8').replace(
+        new RegExp(searchString, 'g'),
+        replaceString,
+      );
+      writeFileSync(filePath, updatedContent, 'utf-8');
+    } catch (error) {
+      console.error(`An error occurred while processing ${filePath}: `, error);
+    }
+  };
+}
 
 export default defineConfig([
   {
@@ -6,7 +25,7 @@ export default defineConfig([
     dts: true,
     entry: ['src/index.ts'],
     format: ['esm', 'cjs'],
-    onSuccess: "sed -i '' 's/import/require/g' dist/index.js",
+    onSuccess: replaceStringInFile('dist/index.js', 'import', 'require'),
   },
   {
     clean: true,


### PR DESCRIPTION
I could not get the build script to run cleanly on Linux. The build succeeds but I see an error message from the `onSuccess` command.

The `sed` command has a slightly different syntax on my system (Pop!_OS). 
Having a short JS code to accomplish the same would make the build more portable.

![image](https://github.com/decs/typeschema/assets/20662/b7095882-02e4-4c23-a399-3394d03b492c)
