### PR TITLE
Fix Schema is not inferred when typebox is not installed for @typeschema/main

### DIFF
--- a/packages/main/src/selector.ts
+++ b/packages/main/src/selector.ts
@@ -1,13 +1,11 @@
 import type {AdapterResolvers} from './adapters';
 import type {AdapterResolver} from './resolver';
-import type {Kind} from '@sinclair/typebox';
 import type {IfDefined, SchemaFrom} from '@typeschema/core';
 import type {CoreValidator} from 'suretype';
 
 // prettier-ignore
 type IsTypeboxSchema<TSchema> =
-  [IfDefined<typeof Kind>] extends [never] ? false
-  : TSchema extends {[Kind]: unknown} ? true
+  TSchema extends {static: unknown, params: unknown[]} ? true
   : false;
 function isTypeboxSchema(
   schema: SchemaFrom<AdapterResolver>,


### PR DESCRIPTION
When using `@typeschema/main`, a validation library other that typebox and its adapter, typeschema will try to infer all Schemas as typebox Schemas, due to the `IsTypeboxSchema` type always returning true which is caused by a missing import of `@sinclair/typebox`. A workaround is to install `@sinclair/typebox`, which is not ideal for libraries. (See #63) 

My solution is to not use the `Kind` symbol to detect a Typebox Schema at the type level, but to use the properties `static` and `params` that are guaranteed to be in the [Typebox TSchema](https://github.com/sinclairzx81/typebox/blob/master/src/type/schema/schema.ts#L52) instead.

I've run the tests and tried out the modified code with zod, suretype and typebox in various configurations, there seem to not be any issues.

I'm not quite sure how this works with Typebox' custom type system, but i couldn't find more documentation about their custom types for now